### PR TITLE
builder.conf: Add python-yaml or PyYAML depending on host distribution

### DIFF
--- a/builder.conf
+++ b/builder.conf
@@ -88,7 +88,11 @@ else
     _template_flavor_salt := 
 endif
 
-DEPENDENCIES += python-yaml
+ifeq ($(PKG_MANAGER),dpkg)
+ DEPENDENCIES += python-yaml
+else ifeq ($(PKG_MANAGER),rpm)
+ DEPENDENCIES += PyYAML
+endif
 
 TEMPLATE_FLAVOR_SALT := $(_template_flavor_salt)
 ifneq "$(TEMPLATE_FLAVOR_SALT)" ""


### PR DESCRIPTION
Depends on the following pull request: https://github.com/marmarek/qubes-builder/pull/6
